### PR TITLE
Change psr/log dependency to be more flexible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
   "require": {
     "ext-json": "*",
     "php": ">=7.4.0",
-    "psr/log": "^1.1"
+    "psr/log": ">=1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.4",


### PR DESCRIPTION
See #34 , the current psr/log dependency breaks when trying to use with newer versions of `monolog >= 3` (as required by Laravel 10)

The only changes in newer psr/log versions is to make it more compatible with newer php versions

An alternative to my proposed change would be `^1.0.1 || ^2.0 || ^3.0` (which is equivalent to monolog 2.x )