### PR TITLE
Fix custom pattern with escaped characters

### DIFF
--- a/examples/templates/t_8.txt
+++ b/examples/templates/t_8.txt
@@ -5,6 +5,7 @@ Sender-id: {%senderId%}
 Sender-full-name: {%senderName%}
 Sender-email: {%senderEmail%}
 Sender-website: {%senderSite%}
+Sender-number: {%senderPhone:\+[0-9]{10,15}%}
 Sender-nationality: {%senderCountry%}
 Message:
 {%senderMessage%}

--- a/examples/test_txt_files/m_8.txt
+++ b/examples/test_txt_files/m_8.txt
@@ -5,6 +5,7 @@ Sender-id: 12345678
 Sender-full-name: John Anthony Doe
 Sender-email: example@test.com
 Sender-website: www.example.com/something
+Sender-number: +4917914999410
 Sender-nationality: N/A
 Message:
 Some Text Goes Here - Some Text Goes Here

--- a/src/Helper/TemplatesHelper.php
+++ b/src/Helper/TemplatesHelper.php
@@ -8,6 +8,15 @@ use aymanrb\UnstructuredTextParser\Exception\InvalidTemplatesDirectoryException;
 
 class TemplatesHelper
 {
+    private const REGEX_GENERIC_VARIABLE = '/\\\{%(.*)%\\\}/U'; //{%Var%}
+    private const REGEX_VARIABLE_WITH_PATTERN = '/\\\{%([^%]+):(.*)%\\\}/U'; //{%Var:Pattern%}
+    private const REGEX_PREPARED_VARIABLE_WITH_PATTERN = '/(\(\?[^)]*)./'; //(?<Var\>Pattern)
+    private const REGEX_ORPHAN_BACKSLASH = '/(?<!\\\\)\\\\(?!\\\\)/';
+    private const STR_SEARCH_TRIPLE_BACKSLASHES = '\\\\\\';
+
+    private const REPLACE_GENERIC_VARIABLE = '(?<$1>.*)'; //(?<Var>.*)
+    private const REPLACE_VARIABLE_WITH_PATTERN = '(?<$1>$2)'; //(?<Var>Pattern)
+
     private \FilesystemIterator $directoryIterator;
 
     public function __construct(string $templatesDir)
@@ -76,19 +85,26 @@ class TemplatesHelper
     {
         $templateText = preg_quote($templateText, '/');
 
-        // replace all {%Var:Pattern%} in the template with (?<Var>Pattern) regex vars
-        $templateText =  preg_replace('/\\\{%([^%]+):(.*)%\\\}/U', '(?<$1>$2)', $templateText);
+        $templateText =  preg_replace(
+            self::REGEX_VARIABLE_WITH_PATTERN,
+            self::REPLACE_VARIABLE_WITH_PATTERN,
+            $templateText
+        );
 
-        // remove the regex escaped characters of the provided patterns
         $templateText = preg_replace_callback(
-            '/(\(\?[^)]*)./',
+            self::REGEX_PREPARED_VARIABLE_WITH_PATTERN,
             function ($matches) {
-                return str_replace('\\', '', $matches[0]);
+                $variableWithPattern = preg_replace(self::REGEX_ORPHAN_BACKSLASH, '', $matches[0]);
+
+                return str_replace(self::STR_SEARCH_TRIPLE_BACKSLASHES, '\\', $variableWithPattern);
             },
             $templateText
         );
 
-        // replace all {%Var%} in the template with (?<Var>.*) regex vars
-        return preg_replace('/\\\{%(.*)%\\\}/U', '(?<$1>.*)', $templateText);
+        return preg_replace(
+            self::REGEX_GENERIC_VARIABLE,
+            self::REPLACE_GENERIC_VARIABLE,
+            $templateText
+        );
     }
 }

--- a/tests/Helper/expected_templates/temp4.txt
+++ b/tests/Helper/expected_templates/temp4.txt
@@ -1,0 +1,1 @@
+Template with specified pattern containing special escaped characters (?<variable>\+[0-9]{10,16})

--- a/tests/Helper/helper_templates/temp4.txt
+++ b/tests/Helper/helper_templates/temp4.txt
@@ -1,0 +1,1 @@
+Template with specified pattern containing special escaped characters {%variable:\+[0-9]{10,16}%}


### PR DESCRIPTION
This should fix part of the issue reported in #37 when an escaped character is provided in the custom pattern
